### PR TITLE
Add versioned theme support and release CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,47 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version tag (e.g., v6)'
+        required: true
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate version format
+        run: |
+          if [[ ! "${{ inputs.version }}" =~ ^v[0-9]+$ ]]; then
+            echo "Error: version must match pattern vN (e.g., v6)"
+            exit 1
+          fi
+
+      - name: Update theme name in CSS
+        run: |
+          sed -i 's|/\* @theme ai_friendly \*/|/* @theme ai_friendly_${{ inputs.version }} */|' themes/ai_friendly.css
+
+      - name: Update theme name in example.md
+        run: |
+          sed -i 's/^theme: ai_friendly$/theme: ai_friendly_${{ inputs.version }}/' example.md
+
+      - name: Verify changes
+        run: |
+          head -1 themes/ai_friendly.css
+          grep '^theme:' example.md
+
+      - name: Commit and tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git commit -am "Release ${{ inputs.version }}"
+          git tag "${{ inputs.version }}"
+
+      - name: Push tag
+        run: |
+          git push origin "refs/tags/${{ inputs.version }}"

--- a/README.md
+++ b/README.md
@@ -7,9 +7,25 @@
 
 ## Usage
 
-**Just copy a single markdown file to get started.** Each markdown file contains the theme version in its frontmatter and full setup instructions (theme download, VSCode configuration, and CLI build commands) in an HTML comment block.
+**Just copy a single markdown file to get started.** Each markdown file contains setup instructions in an HTML comment block. Ask your AI coding assistant (Claude Code, Cursor, GitHub Copilot, etc.) to read the markdown file — it will handle theme download, VSCode setup, and PDF/HTML builds.
 
-Ask your AI coding assistant (Claude Code, Cursor, GitHub Copilot, etc.) to read the markdown file — it will automatically handle theme download, VSCode setup, and PDF/HTML builds.
+### Theme versioning
+
+The theme version is specified via the `theme` property in the frontmatter:
+
+```yaml
+theme: ai_friendly      # latest (main branch)
+theme: ai_friendly_v4   # pinned to v4
+```
+
+When a version is pinned (e.g., `ai_friendly_v4`), the theme CSS is fetched from the corresponding git tag. The CSS at each tag registers itself as `ai_friendly_vN` via `/* @theme ai_friendly_vN */`, so multiple versions can coexist.
+
+### Release process
+
+1. Update `/* @theme ai_friendly */` → `/* @theme ai_friendly_vN */` in `themes/ai_friendly.css`
+2. Update `theme: ai_friendly` → `theme: ai_friendly_vN` in `example.md`
+3. Tag as `vN`
+4. Revert both changes on main
 
 ### GitHub Codespace
 

--- a/example.md
+++ b/example.md
@@ -3,35 +3,37 @@ marp: true
 theme: ai_friendly
 paginate: true
 math: katex
-ai_friendly_version: v4
 ---
 
 <!--
-[AI-Friendly Theme]
-https://github.com/sotetsuk/marp-ai-friendly
+[AI-Friendly Theme] https://github.com/sotetsuk/marp-ai-friendly
+theme: ai_friendly → latest (main), ai_friendly_vN → pinned (tag vN)
 
 ## Setup
 
-### Download theme
-mkdir -p /tmp/marp-themes && curl -sL -o /tmp/marp-themes/ai_friendly-${ai_friendly_version}.css \
-  https://raw.githubusercontent.com/sotetsuk/marp-ai-friendly/refs/tags/${ai_friendly_version}/themes/ai_friendly.css
+### CLI
+# ${theme}=theme property value, ${version}=version suffix (or "main" if no suffix)
+# Use refs/heads/main instead of refs/tags/${version} for ai_friendly (no suffix)
+mkdir -p .marp-themes && curl -sL -o .marp-themes/${theme}.css \
+  https://raw.githubusercontent.com/sotetsuk/marp-ai-friendly/refs/tags/${version}/themes/ai_friendly.css
+grep -qxF '.marp-themes/' .gitignore 2>/dev/null || echo '.marp-themes/' >> .gitignore
 
-### VSCode preview (.vscode/settings.json)
-{
-  "markdown.marp.themes": [
-    "https://raw.githubusercontent.com/sotetsuk/marp-ai-friendly/refs/tags/${ai_friendly_version}/themes/ai_friendly.css"
-  ]
-}
+cat > .marprc.yml << 'EOF'
+themeSet: [.marp-themes/]
+allowLocalFiles: true
+EOF
 
-### CLI (PDF)
-npx @marp-team/marp-cli slides.md \
-  --theme-set /tmp/marp-themes/ai_friendly-${ai_friendly_version}.css \
-  --pdf -o output.pdf --allow-local-files --no-stdin
+### VSCode — merge into existing .vscode/settings.json if present
+mkdir -p .vscode && echo '{"markdown.marp.themes":[' \
+  $(git ls-remote --tags https://github.com/sotetsuk/marp-ai-friendly.git 2>/dev/null \
+  | grep -o 'refs/tags/v[0-9]*$' | sed 's|refs/tags/||' | sort -V | awk '$0>="v6"' \
+  | while read v; do echo "\"https://raw.githubusercontent.com/sotetsuk/marp-ai-friendly/refs/tags/$v/themes/ai_friendly.css\","; done) \
+  '"https://raw.githubusercontent.com/sotetsuk/marp-ai-friendly/refs/heads/main/themes/ai_friendly.css"]}' \
+  | python3 -m json.tool > .vscode/settings.json
 
-### CLI (HTML)
-npx @marp-team/marp-cli slides.md \
-  --theme-set /tmp/marp-themes/ai_friendly-${ai_friendly_version}.css \
-  --html -o output.html --allow-local-files --no-stdin
+## Build
+npx @marp-team/marp-cli slides.md --pdf -o output.pdf --no-stdin
+npx @marp-team/marp-cli slides.md --html -o output.html --no-stdin
 -->
 
 # AI Friendly Theme


### PR DESCRIPTION
## Summary
- Embed theme version in the `theme` property (e.g., `theme: ai_friendly_v6`) so each md file pins its own version
- Add AI-friendly setup instructions as HTML comments in `example.md` covering CLI (download + `.marprc.yml`) and VSCode (auto-generate `.vscode/settings.json` with all version URLs)
- Add GitHub Actions release workflow (`workflow_dispatch`) that automates `@theme` rewriting and tagging
- Update README to document versioning scheme and release process

## Test plan
- [ ] `make pdf` builds successfully with updated `example.md`
- [ ] CLI setup commands download theme to `.marp-themes/` and build PDF/HTML via `.marprc.yml`
- [ ] VSCode one-liner generates correct `.vscode/settings.json` with all v6+ version URLs
- [ ] Release workflow (`workflow_dispatch` with version input) rewrites CSS `@theme`, updates `example.md`, and creates tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)