### PR TITLE
Add CI to auto-update example.pdf on main push

### DIFF
--- a/.github/workflows/update-pdf.yml
+++ b/.github/workflows/update-pdf.yml
@@ -1,0 +1,44 @@
+name: Update example.pdf
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - 'example.pdf'
+
+jobs:
+  build-pdf:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install Marp CLI
+        run: npm install -g @marp-team/marp-cli
+
+      - name: Install Chrome dependencies
+        run: npx playwright install --with-deps chromium
+
+      - name: Build PDF
+        run: make pdf
+
+      - name: Copy PDF to root
+        run: cp dist/example.pdf example.pdf
+
+      - name: Commit and push if changed
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add example.pdf
+          if git diff --cached --quiet; then
+            echo "No changes to example.pdf"
+          else
+            git commit -m "Update example.pdf"
+            git push
+          fi


### PR DESCRIPTION
## Summary
- mainブランチへのpush時にMarp CLIでexample.pdfを自動再ビルドするCIワークフローを追加
- 差分がある場合のみコミット&プッシュし、`paths-ignore`で無限ループを防止

## Test plan
- [ ] mainにマージ後、example.mdやテーマCSSを変更してpushし、CIがPDFを更新することを確認
- [ ] example.pdf以外に変更がない場合、空コミットが作られないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)