### PR TITLE
Unify CLI and VSCode setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 
 **Just copy a single markdown file to get started.** Each markdown file contains setup instructions in an HTML comment block. Ask your AI coding assistant (Claude Code, Cursor, GitHub Copilot, etc.) to read the markdown file — it will handle theme download, VSCode setup, and PDF/HTML builds.
 
+> Prompt example: `Read slide.md and run the setup commands in the HTML comment block.`
+
 ### Theme versioning
 
 The theme version is specified via the `theme` property in the frontmatter:

--- a/example.md
+++ b/example.md
@@ -10,26 +10,24 @@ math: katex
 theme: ai_friendly → latest (main), ai_friendly_vN → pinned (tag vN)
 
 ## Setup
+# When switching theme versions, re-run the corresponding setup commands below.
+# ${theme}: theme property value (ai_friendly or ai_friendly_vN)
+# ${ref}:   refs/heads/main (for ai_friendly) or refs/tags/vN (for ai_friendly_vN)
 
-### CLI
-# ${theme}=theme property value, ${version}=version suffix (or "main" if no suffix)
-# Use refs/heads/main instead of refs/tags/${version} for ai_friendly (no suffix)
 mkdir -p .marp-themes && curl -sL -o .marp-themes/${theme}.css \
-  https://raw.githubusercontent.com/sotetsuk/marp-ai-friendly/refs/tags/${version}/themes/ai_friendly.css
+  https://raw.githubusercontent.com/sotetsuk/marp-ai-friendly/${ref}/themes/ai_friendly.css
 grep -qxF '.marp-themes/' .gitignore 2>/dev/null || echo '.marp-themes/' >> .gitignore
+grep -qxF '.marprc.yml' .gitignore 2>/dev/null || echo '.marprc.yml' >> .gitignore
 
 cat > .marprc.yml << 'EOF'
 themeSet: [.marp-themes/]
 allowLocalFiles: true
 EOF
 
-### VSCode — merge into existing .vscode/settings.json if present
-mkdir -p .vscode && echo '{"markdown.marp.themes":[' \
-  $(git ls-remote --tags https://github.com/sotetsuk/marp-ai-friendly.git 2>/dev/null \
-  | grep -o 'refs/tags/v[0-9]*$' | sed 's|refs/tags/||' | sort -V | awk '$0>="v6"' \
-  | while read v; do echo "\"https://raw.githubusercontent.com/sotetsuk/marp-ai-friendly/refs/tags/$v/themes/ai_friendly.css\","; done) \
-  '"https://raw.githubusercontent.com/sotetsuk/marp-ai-friendly/refs/heads/main/themes/ai_friendly.css"]}' \
-  | python3 -m json.tool > .vscode/settings.json
+# Merge into existing .vscode/settings.json if present
+mkdir -p .vscode && cat > .vscode/settings.json << EOF
+{"markdown.marp.themes": ["https://raw.githubusercontent.com/sotetsuk/marp-ai-friendly/${ref}/themes/ai_friendly.css"]}
+EOF
 
 ## Build
 npx @marp-team/marp-cli slides.md --pdf -o output.pdf --no-stdin


### PR DESCRIPTION
## Summary
- Unified version variables (`${theme}`, `${ref}`) across CLI and VSCode setup commands in `example.md`
- Simplified VSCode setup from a complex `git ls-remote` pipeline to a single URL (consistent with CLI)
- Added `.marprc.yml` to `.gitignore`
- Added AI prompt example to `README.md`

## Test plan
- [ ] Verify setup commands in `example.md` HTML comment are correct and runnable
- [ ] Confirm `example.pdf` is regenerated correctly by CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)