### PR TITLE
Remove h3 left border line

### DIFF
--- a/themes/ai_friendly.css
+++ b/themes/ai_friendly.css
@@ -88,13 +88,11 @@ section::after {
    ========================================================================== */
 
 h3 {
-  border-left: 15px solid var(--primary);
   color: var(--primary);
   font-size: 1.0em;
   margin-left: 0px;
   margin-top: 0.5em;
   margin-bottom: 0.5em;
-  padding-left: var(--space-xs);
 }
 
 h3 strong {


### PR DESCRIPTION
## Summary
- Remove the vertical border-left decoration from h3 elements in the ai_friendly theme
- Also removes the associated padding-left that was only needed for the border spacing

## Test plan
- [ ] Verify h3 elements render without the left border line
- [ ] Check that h3 styling (color, font-size, margins) remains intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)