### PR TITLE
Change theme dir to themes/ and remove .gitignore steps

### DIFF
--- a/example.md
+++ b/example.md
@@ -14,13 +14,11 @@ theme: ai_friendly → latest (main), ai_friendly_vN → pinned (tag vN)
 # ${theme}: theme property value (ai_friendly or ai_friendly_vN)
 # ${ref}:   refs/heads/main (for ai_friendly) or refs/tags/vN (for ai_friendly_vN)
 
-mkdir -p .marp-themes && curl -sL -o .marp-themes/${theme}.css \
+mkdir -p themes && curl -sL -o themes/${theme}.css \
   https://raw.githubusercontent.com/sotetsuk/marp-ai-friendly/${ref}/themes/ai_friendly.css
-grep -qxF '.marp-themes/' .gitignore 2>/dev/null || echo '.marp-themes/' >> .gitignore
-grep -qxF '.marprc.yml' .gitignore 2>/dev/null || echo '.marprc.yml' >> .gitignore
 
 cat > .marprc.yml << 'EOF'
-themeSet: [.marp-themes/]
+themeSet: [themes/]
 allowLocalFiles: true
 EOF
 


### PR DESCRIPTION
## Summary
- テーマCSSのダウンロード先を `.marp-themes/` から `themes/` に変更
- `.gitignore` への追加手順（`.marp-themes/` と `.marprc.yml`）を削除
- `.marprc.yml` の `themeSet` パスを `themes/` に更新

## Rationale
テーマCSSは小さなファイルが数個程度なので、gitignoreせずコミットする方がシンプルで再現性も高い。共同作業者はcloneするだけでビルドでき、CI/CDでもダウンロード手順が不要になる。

## Test plan
- [ ] セットアップ手順に従い `themes/` にCSSがダウンロードされることを確認
- [ ] `npx @marp-team/marp-cli` でPDF/HTMLビルドが成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)