### PR TITLE
Rename images target to png and fix output path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,13 +36,13 @@ html: $(OUTPUT_DIR)
 		--allow-local-files
 
 # Export individual slide images as PNG
-.PHONY: images
-images: $(OUTPUT_DIR)
+.PHONY: png
+png: $(OUTPUT_DIR)
 	$(MARP_CLI) $(INPUT_FILE) \
 		--theme-set $(THEME_DIR)/ai_friendly.css \
 		--images png \
 		--image-scale 2 \
-		--output $(OUTPUT_DIR)/ \
+		--output $(OUTPUT_DIR)/example.png \
 		--allow-local-files
 
 # Preview in browser


### PR DESCRIPTION
## Summary
- Rename Makefile target from `images` to `png` for clarity
- Fix PNG export output path: `--output dist/` produces files without `.png` extension, changed to `--output dist/example.png` for proper `dist/example.001.png` naming

## Test plan
- [ ] Run `make png` and verify PNG files are created with correct `.png` extensions in `dist/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)