### PR TITLE
Add default image centering without figure-wrapper

### DIFF
--- a/example.md
+++ b/example.md
@@ -103,15 +103,10 @@ $$
 
 ---
 
-## 画像配置の例 `center`
-
-<div class="figure-wrapper center">
+## 画像配置の例（デフォルト）
 
 ![](images/ef6ff5b23265f052edd37ac235bd4e703501e287f92bbdf2ef48b995682b37cf.jpg)
-
-**図14.31**: マルチタスク密予測問題の図解。[EF15]の図1より。Rob Fergus氏の許可を得て使用。
-
-</div>
+<small>**図14.31**: マルチタスク密予測問題の図解。[EF15]の図1より。Rob Fergus氏の許可を得て使用。</small>
 
 
 ---

--- a/themes/ai_friendly.css
+++ b/themes/ai_friendly.css
@@ -78,6 +78,11 @@ section {
   color: var(--text-primary);
 }
 
+section:not(:has(.figure-wrapper)) {
+  display: flex;
+  flex-direction: column;
+}
+
 section::after {
   font-weight: 700;
   color: var(--text-secondary);
@@ -249,6 +254,34 @@ img[alt~="right"] {
   width: auto;
   height: auto;
   object-fit: contain;
+}
+
+/* Default Image Centering (bare images without figure-wrapper)
+   ========================================================================== */
+section > p:has(img) {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  flex: 1;
+  margin: 0;
+  width: 100%;
+}
+
+section > p:has(img) img {
+  max-width: 100%;
+  max-height: 65vh;
+  width: auto;
+  height: auto;
+  margin: 0;
+}
+
+section > p:has(img) small {
+  font-size: 0.5em;
+  color: var(--text-secondary);
+  text-align: center;
+  margin: 0;
+  display: block;
 }
 
 /* Clear float if needed */


### PR DESCRIPTION
## Summary
- Bare images (`![](image.jpg)`) now automatically center vertically and horizontally, matching existing `figure-wrapper center` behavior
- Captions supported via `<small>` tag on the next line (no blank line) after the image
- `section:not(:has(.figure-wrapper))` ensures `figure-wrapper right` and other layouts are unaffected

## Usage
```markdown
![](image.jpg)
<small>**Caption**: description text</small>
```

## Test plan
- [ ] Verify default image slide matches `figure-wrapper center` layout
- [ ] Verify `figure-wrapper right` slide is unaffected
- [ ] Verify `figure-wrapper center withtext` slide is unaffected
- [ ] Verify non-image slides (text, code, table) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)