### PR TITLE
Add .centered-figure class for text + image + text layouts

### DIFF
--- a/example.md
+++ b/example.md
@@ -157,6 +157,25 @@ $$
 
 ---
 
+## 画像配置の例 `centered-figure`（上下にテキスト）
+
+<div class="centered-figure">
+
+> <span class="b">前提</span>: 入力は正規化された画像テンソル
+
+- 典型的な前処理: リサイズ → 正規化 → テンソル化
+
+![](images/52978b96dd928aff6ed0bef9aed961083a8e376e2e72369c194abdbd7cbad9c3.jpg)
+
+**図**: 入力画像の例（3クラス分類タスク）
+
+- 出力は各クラスの確率分布
+- 推論時は `argmax` でクラスを決定
+
+</div>
+
+---
+
 ## コードブロックの例
 
 ```python

--- a/themes/ai_friendly.css
+++ b/themes/ai_friendly.css
@@ -268,6 +268,49 @@ img[alt~="right"] {
   clear: both;
 }
 
+/* Centered figure: wraps arbitrary text above/below an image and
+   centers the image in the remaining vertical space.
+   ========================================================================== */
+.centered-figure {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: var(--space-sm);
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  padding: 0;
+}
+
+.centered-figure > * {
+  max-width: 100%;
+  margin: 0;
+}
+
+.centered-figure > p:has(> img) {
+  text-align: center;
+  flex: 1 1 auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 0;
+  width: 100%;
+}
+
+.centered-figure > p:has(> img) > img {
+  max-width: 100%;
+  max-height: 100%;
+  object-fit: contain;
+  margin: 0 auto;
+}
+
+.centered-figure > p:has(> img) + p {
+  font-size: 0.5em;
+  color: var(--text-secondary);
+  text-align: center;
+}
+
 /* Footnote
    ========================================================================== */
 .footnote {


### PR DESCRIPTION
## Summary
- New `.centered-figure` layout class: wraps text above, an image, and text below in one `<div>`. Flexbox auto-distributes vertical space — text blocks size to their content, the image paragraph grows (`flex: 1 1 auto`) to absorb the remaining middle, and the image is centered inside that gap via `object-fit: contain`.
- The existing `.figure-wrapper.withtext` is left untouched for backward compatibility.
- Added one demo slide to `example.md` showing the distinctive case (text above AND below the image) that the old class could not handle.

## Test plan
- [x] `make png` regenerates all 13 slides without errors
- [x] New slide 10 (`centered-figure`) renders with text above, image centered in the middle, caption + text below — all visible within the slide bounds
- [x] Existing slide 8 (`.figure-wrapper.withtext`) renders unchanged (regression check)
- [x] Existing slides 7 (`center`) and 9 (`right`) render unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)