### PR TITLE
Add Obsidian Callout syntax support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ $(OUTPUT_DIR):
 .PHONY: pdf
 pdf: $(OUTPUT_DIR)
 	$(MARP_CLI) $(INPUT_FILE) \
+		--config-file marp.config.mjs \
 		--theme-set $(THEME_DIR)/ai_friendly.css \
 		--pdf \
 		--output $(PDF_OUTPUT) \
@@ -30,6 +31,7 @@ pdf: $(OUTPUT_DIR)
 .PHONY: html
 html: $(OUTPUT_DIR)
 	$(MARP_CLI) $(INPUT_FILE) \
+		--config-file marp.config.mjs \
 		--theme-set $(THEME_DIR)/ai_friendly.css \
 		--html \
 		--output $(HTML_OUTPUT) \
@@ -39,6 +41,7 @@ html: $(OUTPUT_DIR)
 .PHONY: png
 png: $(OUTPUT_DIR)
 	$(MARP_CLI) $(INPUT_FILE) \
+		--config-file marp.config.mjs \
 		--theme-set $(THEME_DIR)/ai_friendly.css \
 		--images png \
 		--image-scale 2 \
@@ -49,6 +52,7 @@ png: $(OUTPUT_DIR)
 .PHONY: preview
 preview:
 	$(MARP_CLI) $(INPUT_FILE) \
+		--config-file marp.config.mjs \
 		--theme-set $(THEME_DIR)/ai_friendly.css \
 		--preview \
 		--allow-local-files

--- a/README.md
+++ b/README.md
@@ -28,6 +28,38 @@ Run the Release workflow from GitHub Actions (or `gh workflow run release.yml -f
 
 With Claude Code, you can also use the `/release` slash command.
 
+### Obsidian Callouts
+
+このテーマは [Obsidian Callout](https://help.obsidian.md/callouts) 構文を完全に再現する追加文法をサポートします (動的な折りたたみは静的描画のみ)。`setup.sh` が `marp.config.mjs` を配置し、Marp CLI/VSCode 拡張の双方で利用できます。
+
+```markdown
+> [!NOTE] タイトル
+> 本文。**Markdown** や `code`、$E = mc^2$ も利用可能。
+```
+
+サポートするタイプ (エイリアスを含む):
+
+| Type | Aliases |
+|---|---|
+| `note` | — |
+| `abstract` | `summary`, `tldr` |
+| `info` | — |
+| `todo` | — |
+| `tip` | `hint`, `important` |
+| `success` | `check`, `done` |
+| `question` | `help`, `faq` |
+| `warning` | `caution`, `attention` |
+| `failure` | `fail`, `missing` |
+| `danger` | `error` |
+| `bug` | — |
+| `example` | — |
+| `quote` | `cite` |
+
+折りたたみ構文 `[!TYPE]+` / `[!TYPE]-` は受理されますが、本テーマでは静的に表示します (アニメーションなし)。未知のタイプは通常の blockquote として表示されます。
+
+> [!NOTE]
+> VSCode の Marp 拡張で Callout を有効化するには、Workspace Trust を許可してください (`marp.config.mjs` を読み込むため)。
+
 ### GitHub Codespace
 
 You can also clone this repo and open with GitHub Codespace:

--- a/example.md
+++ b/example.md
@@ -10,8 +10,8 @@ GitHub repo   : https://github.com/sotetsuk/marp-ai-friendly
 VERSION       : ai_friendly → latest (main), ai_friendly_vN → pinned (tag vN)
 Setup (latest): curl -sL https://raw.githubusercontent.com/sotetsuk/marp-ai-friendly/refs/heads/main/setup.sh | sh
 Setup (pinned): export VERSION=vN && curl -sL https://raw.githubusercontent.com/sotetsuk/marp-ai-friendly/refs/tags/${VERSION}/setup.sh | sh
-Build (pdf)   : npx @marp-team/marp-cli slide.md --pdf -o output.pdf --no-stdin
-Build (html)  : npx @marp-team/marp-cli slide.md --html -o output.html --no-stdin
+Build (pdf)   : npx @marp-team/marp-cli slide.md --config-file marp.config.mjs --pdf -o output.pdf --no-stdin
+Build (html)  : npx @marp-team/marp-cli slide.md --config-file marp.config.mjs --html -o output.html --no-stdin
 -->
 
 # AI Friendly Theme<br>(Long Title Example)
@@ -215,4 +215,79 @@ normal
 ✅ success
 
 </div>
+
+---
+
+## Obsidian Callout: 基本タイプ
+
+> [!note] Note
+> 一般的なメモ。デフォルトのコールアウト。
+
+> [!tip] Tip
+> 役立つヒントや小技 (`hint`, `important` も同義)。
+
+> [!warning] Warning
+> 注意が必要な情報 (`caution`, `attention` も同義)。
+
+---
+
+## Obsidian Callout: 情報・成功系
+
+> [!abstract] Abstract
+> 要約・概要 (`summary`, `tldr` も同義)。
+
+> [!info] Info
+> 補足情報。
+
+> [!success] Success
+> 完了・成功を示す (`check`, `done` も同義)。
+
+---
+
+## Obsidian Callout: タスク・疑問・エラー系
+
+> [!todo] Todo
+> 未完了タスク。
+
+> [!question] Question
+> 質問・疑問点 (`help`, `faq` も同義)。
+
+> [!failure] Failure
+> 失敗・不足 (`fail`, `missing` も同義)。
+
+---
+
+## Obsidian Callout: 警告・バグ・例示系
+
+> [!danger] Danger
+> 重大な警告・エラー (`error` も同義)。
+
+> [!bug] Bug
+> バグ報告。
+
+> [!example] Example
+> 例示・サンプル。
+
+---
+
+## Obsidian Callout: 引用と構文バリエーション
+
+> [!quote] Quote
+> 引用 (`cite` も同義)。
+
+> [!note]
+> タイトル省略時はデフォルトの "Note" が使われる。
+
+> [!warning]+ 折りたたみ構文 `[!type]+` / `[!type]-` も受理
+> `data-callout-fold` 属性で出力 (静的表示)。
+
+---
+
+## Obsidian Callout: 本文も Markdown 対応
+
+> [!tip] **強調**された*タイトル*と `code` も使える
+> 本文も Markdown としてレンダリングされる:
+> - 箇条書き、**強調**、`inline code`
+> - 数式 $E = mc^2$ もそのまま使える
+> - リンクや引用、テーブルも利用可能
 

--- a/marp.config.mjs
+++ b/marp.config.mjs
@@ -1,0 +1,125 @@
+// Marp configuration for marp-ai-friendly
+//
+// Adds Obsidian-style callout syntax support to Marp's markdown parser.
+//
+//   > [!NOTE] Optional title
+//   > Body line 1
+//   > Body line 2
+//
+// Supported types (with aliases) mirror Obsidian's default callouts:
+//   note, abstract|summary|tldr, info, todo, tip|hint|important,
+//   success|check|done, question|help|faq, warning|caution|attention,
+//   failure|fail|missing, danger|error, bug, example, quote|cite
+//
+// Foldable suffix `+`/`-` is accepted (rendered statically; no animation).
+// Unknown types fall through as ordinary blockquotes.
+
+const ALIASES = {
+  note: 'note',
+  abstract: 'abstract', summary: 'abstract', tldr: 'abstract',
+  info: 'info',
+  todo: 'todo',
+  tip: 'tip', hint: 'tip', important: 'tip',
+  success: 'success', check: 'success', done: 'success',
+  question: 'question', help: 'question', faq: 'question',
+  warning: 'warning', caution: 'warning', attention: 'warning',
+  failure: 'failure', fail: 'failure', missing: 'failure',
+  danger: 'danger', error: 'danger',
+  bug: 'bug',
+  example: 'example',
+  quote: 'quote', cite: 'quote',
+};
+
+const DEFAULT_TITLES = {
+  note: 'Note', abstract: 'Abstract', info: 'Info', todo: 'Todo',
+  tip: 'Tip', success: 'Success', question: 'Question', warning: 'Warning',
+  failure: 'Failure', danger: 'Danger', bug: 'Bug', example: 'Example',
+  quote: 'Quote',
+};
+
+const CALLOUT_RE = /^\[!([A-Za-z][\w-]*)\]([+-]?)[ \t]*([^\n]*)(?:\n([\s\S]*))?$/;
+
+function obsidianCallouts(md) {
+  md.core.ruler.after('block', 'obsidian_callout', (state) => {
+    const Token = state.Token;
+    const tokens = state.tokens;
+
+    for (let i = 0; i < tokens.length; i++) {
+      if (tokens[i].type !== 'blockquote_open') continue;
+      if (tokens[i + 1]?.type !== 'paragraph_open') continue;
+      if (tokens[i + 2]?.type !== 'inline') continue;
+      if (tokens[i + 3]?.type !== 'paragraph_close') continue;
+
+      const inline = tokens[i + 2];
+      const m = CALLOUT_RE.exec(inline.content);
+      if (!m) continue;
+
+      const rawType = m[1].toLowerCase();
+      const type = ALIASES[rawType];
+      if (!type) continue;
+
+      const fold = m[2];
+      const titleText = (m[3] || '').trim();
+      const bodyText = m[4] || '';
+
+      let depth = 1;
+      let closeIdx = -1;
+      for (let j = i + 1; j < tokens.length; j++) {
+        if (tokens[j].type === 'blockquote_open') depth++;
+        else if (tokens[j].type === 'blockquote_close') {
+          depth--;
+          if (depth === 0) { closeIdx = j; break; }
+        }
+      }
+      if (closeIdx === -1) continue;
+
+      tokens[i].tag = 'div';
+      tokens[i].attrJoin('class', `callout callout-${type}`);
+      tokens[i].attrSet('data-callout', type);
+      if (fold) tokens[i].attrSet('data-callout-fold', fold === '+' ? 'open' : 'closed');
+      tokens[closeIdx].tag = 'div';
+
+      tokens[i + 1].tag = 'div';
+      tokens[i + 1].attrSet('class', 'callout-title');
+      const titleClosePos = i + 3;
+      tokens[titleClosePos].tag = 'div';
+
+      const titleFinal = titleText || DEFAULT_TITLES[type];
+      inline.content = titleFinal;
+      inline.children = [];
+
+      let insertCount = 0;
+      if (bodyText.trim()) {
+        const pOpen = new Token('paragraph_open', 'p', 1);
+        pOpen.block = true;
+        const pInline = new Token('inline', '', 0);
+        pInline.content = bodyText;
+        pInline.children = [];
+        const pClose = new Token('paragraph_close', 'p', -1);
+        pClose.block = true;
+        tokens.splice(titleClosePos + 1, 0, pOpen, pInline, pClose);
+        insertCount = 3;
+      }
+
+      const shiftedCloseIdx = closeIdx + insertCount;
+      const bodyStart = titleClosePos + 1;
+      if (shiftedCloseIdx > bodyStart) {
+        const contentOpen = new Token('html_block', '', 0);
+        contentOpen.content = '<div class="callout-content">\n';
+        contentOpen.block = true;
+        const contentClose = new Token('html_block', '', 0);
+        contentClose.content = '</div>\n';
+        contentClose.block = true;
+        tokens.splice(bodyStart, 0, contentOpen);
+        tokens.splice(shiftedCloseIdx + 1, 0, contentClose);
+        i = shiftedCloseIdx + 2;
+      } else {
+        i = shiftedCloseIdx;
+      }
+    }
+  });
+}
+
+export default {
+  engine: ({ marp }) => marp.use(obsidianCallouts),
+};

--- a/setup.sh
+++ b/setup.sh
@@ -18,14 +18,18 @@ mkdir -p themes
 echo "Downloading theme: ${THEME} (ref: ${REF})"
 curl -sL -o "themes/${THEME}.css" "${BASE_URL}/themes/ai_friendly.css"
 
-# --- 2. Create .marprc.yml ---
+# --- 2. Download Marp config (Obsidian callout plugin) ---
+curl -sL -o "marp.config.mjs" "${BASE_URL}/marp.config.mjs"
+echo "Downloaded marp.config.mjs"
+
+# --- 3. Create .marprc.yml ---
 cat > .marprc.yml << 'MARPRC'
 themeSet: [themes/]
 allowLocalFiles: true
 MARPRC
 echo "Created .marprc.yml"
 
-# --- 3. Update .vscode/settings.json ---
+# --- 4. Update .vscode/settings.json ---
 URL="${BASE_URL}/themes/ai_friendly.css"
 mkdir -p .vscode
 if command -v python3 >/dev/null 2>&1; then

--- a/themes/ai_friendly.css
+++ b/themes/ai_friendly.css
@@ -538,10 +538,9 @@ pre code {
 .callout {
   --callout-color: 8, 109, 221;
   --callout-icon: url("data:image/svg+xml;utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M21.174 6.812a1 1 0 0 0-3.986-3.987L3.842 16.174a2 2 0 0 0-.5.83l-1.321 4.352a.5.5 0 0 0 .623.622l4.353-1.32a2 2 0 0 0 .83-.497Z'/%3E%3Cpath d='m15 5 4 4'/%3E%3C/svg%3E");
-  border-left: 4px solid rgb(var(--callout-color));
   background-color: rgba(var(--callout-color), 0.1);
   border-radius: var(--radius-md);
-  padding: 0.6em 0.9em;
+  padding: 0.75em 1em;
   margin: var(--space-md) 0;
   break-inside: avoid;
   page-break-inside: avoid;

--- a/themes/ai_friendly.css
+++ b/themes/ai_friendly.css
@@ -533,3 +533,119 @@ pre code {
 .language-html .token.attr-value { color: #e6db74; }
 .language-html .token.comment { color: #75715e; }
 
+/* Obsidian Callouts
+   ========================================================================== */
+.callout {
+  --callout-color: 8, 109, 221;
+  --callout-icon: url("data:image/svg+xml;utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M21.174 6.812a1 1 0 0 0-3.986-3.987L3.842 16.174a2 2 0 0 0-.5.83l-1.321 4.352a.5.5 0 0 0 .623.622l4.353-1.32a2 2 0 0 0 .83-.497Z'/%3E%3Cpath d='m15 5 4 4'/%3E%3C/svg%3E");
+  border-left: 4px solid rgb(var(--callout-color));
+  background-color: rgba(var(--callout-color), 0.1);
+  border-radius: var(--radius-md);
+  padding: 0.6em 0.9em;
+  margin: var(--space-md) 0;
+  break-inside: avoid;
+  page-break-inside: avoid;
+  overflow: hidden;
+}
+
+.callout > .callout-title {
+  display: flex;
+  align-items: center;
+  gap: 0.45em;
+  font-weight: 700;
+  color: rgb(var(--callout-color));
+  margin: 0;
+  padding: 0;
+  line-height: 1.3;
+}
+
+.callout > .callout-title::before {
+  content: '';
+  display: inline-block;
+  width: 1.15em;
+  height: 1.15em;
+  background-color: rgb(var(--callout-color));
+  -webkit-mask-image: var(--callout-icon);
+  mask-image: var(--callout-icon);
+  -webkit-mask-repeat: no-repeat;
+  mask-repeat: no-repeat;
+  -webkit-mask-position: center;
+  mask-position: center;
+  -webkit-mask-size: contain;
+  mask-size: contain;
+  flex-shrink: 0;
+}
+
+.callout > .callout-content {
+  color: var(--text-primary);
+  margin-top: 0.4em;
+}
+
+.callout > .callout-content > :first-child { margin-top: 0; }
+.callout > .callout-content > :last-child { margin-bottom: 0; }
+
+.callout-note {
+  --callout-color: 8, 109, 221;
+  --callout-icon: url("data:image/svg+xml;utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M21.174 6.812a1 1 0 0 0-3.986-3.987L3.842 16.174a2 2 0 0 0-.5.83l-1.321 4.352a.5.5 0 0 0 .623.622l4.353-1.32a2 2 0 0 0 .83-.497Z'/%3E%3Cpath d='m15 5 4 4'/%3E%3C/svg%3E");
+}
+
+.callout-abstract {
+  --callout-color: 0, 191, 188;
+  --callout-icon: url("data:image/svg+xml;utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Crect width='8' height='4' x='8' y='2' rx='1' ry='1'/%3E%3Cpath d='M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2'/%3E%3Cpath d='M12 11h4'/%3E%3Cpath d='M12 16h4'/%3E%3Cpath d='M8 11h.01'/%3E%3Cpath d='M8 16h.01'/%3E%3C/svg%3E");
+}
+
+.callout-info {
+  --callout-color: 0, 184, 252;
+  --callout-icon: url("data:image/svg+xml;utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='12' cy='12' r='10'/%3E%3Cpath d='M12 16v-4'/%3E%3Cpath d='M12 8h.01'/%3E%3C/svg%3E");
+}
+
+.callout-todo {
+  --callout-color: 0, 184, 252;
+  --callout-icon: url("data:image/svg+xml;utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M21.801 10A10 10 0 1 1 17 3.335'/%3E%3Cpath d='m9 11 3 3L22 4'/%3E%3C/svg%3E");
+}
+
+.callout-tip {
+  --callout-color: 0, 191, 188;
+  --callout-icon: url("data:image/svg+xml;utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M8.5 14.5A2.5 2.5 0 0 0 11 12c0-1.38-.5-2-1-3-1.072-2.143-.224-4.054 2-6 .5 2.5 2 4.9 4 6.5 2 1.6 3 3.5 3 5.5a7 7 0 1 1-14 0c0-1.153.433-2.294 1-3a2.5 2.5 0 0 0 2.5 2.5z'/%3E%3C/svg%3E");
+}
+
+.callout-success {
+  --callout-color: 8, 185, 78;
+  --callout-icon: url("data:image/svg+xml;utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M20 6 9 17l-5-5'/%3E%3C/svg%3E");
+}
+
+.callout-question {
+  --callout-color: 222, 200, 62;
+  --callout-icon: url("data:image/svg+xml;utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='12' cy='12' r='10'/%3E%3Cpath d='M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3'/%3E%3Cpath d='M12 17h.01'/%3E%3C/svg%3E");
+}
+
+.callout-warning {
+  --callout-color: 236, 117, 0;
+  --callout-icon: url("data:image/svg+xml;utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3Z'/%3E%3Cpath d='M12 9v4'/%3E%3Cpath d='M12 17h.01'/%3E%3C/svg%3E");
+}
+
+.callout-failure {
+  --callout-color: 233, 49, 71;
+  --callout-icon: url("data:image/svg+xml;utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M18 6 6 18'/%3E%3Cpath d='m6 6 12 12'/%3E%3C/svg%3E");
+}
+
+.callout-danger {
+  --callout-color: 233, 49, 71;
+  --callout-icon: url("data:image/svg+xml;utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M4 14a1 1 0 0 1-.78-1.63l9.9-10.2a.5.5 0 0 1 .86.46l-1.92 6.02A1 1 0 0 0 13 10h7a1 1 0 0 1 .78 1.63l-9.9 10.2a.5.5 0 0 1-.86-.46l1.92-6.02A1 1 0 0 0 11 14z'/%3E%3C/svg%3E");
+}
+
+.callout-bug {
+  --callout-color: 233, 49, 71;
+  --callout-icon: url("data:image/svg+xml;utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m8 2 1.88 1.88'/%3E%3Cpath d='M14.12 3.88 16 2'/%3E%3Cpath d='M9 7.13v-1a3.003 3.003 0 1 1 6 0v1'/%3E%3Cpath d='M12 20c-3.3 0-6-2.7-6-6v-3a4 4 0 0 1 4-4h4a4 4 0 0 1 4 4v3c0 3.3-2.7 6-6 6z'/%3E%3Cpath d='M12 20v-9'/%3E%3Cpath d='M6.53 9C4.6 8.8 3 7.1 3 5'/%3E%3Cpath d='M6 13H2'/%3E%3Cpath d='M3 21c0-2.1 1.7-3.9 3.8-4'/%3E%3Cpath d='M20.97 5c0 2.1-1.6 3.8-3.5 4'/%3E%3Cpath d='M22 13h-4'/%3E%3Cpath d='M17.2 17c2.1.1 3.8 1.9 3.8 4'/%3E%3C/svg%3E");
+}
+
+.callout-example {
+  --callout-color: 120, 82, 238;
+  --callout-icon: url("data:image/svg+xml;utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cline x1='8' x2='21' y1='6' y2='6'/%3E%3Cline x1='8' x2='21' y1='12' y2='12'/%3E%3Cline x1='8' x2='21' y1='18' y2='18'/%3E%3Cline x1='3' x2='3.01' y1='6' y2='6'/%3E%3Cline x1='3' x2='3.01' y1='12' y2='12'/%3E%3Cline x1='3' x2='3.01' y1='18' y2='18'/%3E%3C/svg%3E");
+}
+
+.callout-quote {
+  --callout-color: 158, 158, 158;
+  --callout-icon: url("data:image/svg+xml;utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M16 3a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2 1 1 0 0 1 1 1v1a2 2 0 0 1-2 2 1 1 0 0 0-1 1v2a1 1 0 0 0 1 1 6 6 0 0 0 6-6V5a2 2 0 0 0-2-2z'/%3E%3Cpath d='M5 3a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2 1 1 0 0 1 1 1v1a2 2 0 0 1-2 2 1 1 0 0 0-1 1v2a1 1 0 0 0 1 1 6 6 0 0 0 6-6V5a2 2 0 0 0-2-2z'/%3E%3C/svg%3E");
+}
+


### PR DESCRIPTION
Introduces the full Obsidian callout syntax (> [!TYPE] Title / body)
via a custom markdown-it plugin in marp.config.mjs (no external
dependencies). All 13 Obsidian types are supported with their original
aliases (note, abstract/summary/tldr, info, todo, tip/hint/important,
success/check/done, question/help/faq, warning/caution/attention,
failure/fail/missing, danger/error, bug, example, quote/cite).

Visual design uses Obsidian's exact color palette and Lucide icons
(embedded as inline SVG data URIs via CSS mask-image). The foldable
syntax suffix `[!type]+` / `[!type]-` is accepted and exposed as a
data-callout-fold attribute; no animation is implemented.

setup.sh now also downloads marp.config.mjs alongside the theme CSS so
the curl-based install path keeps working.